### PR TITLE
Overall improvements

### DIFF
--- a/convert_textile_to_markdown.rake
+++ b/convert_textile_to_markdown.rake
@@ -58,11 +58,11 @@ def convert_textile_to_markdown(textile)
   # comment "<!-- -->" (see http://pandoc.org/README.html#ending-a-list)
   # which are unfortunately not supported by Redmine (see http://www.redmine.org/issues/20497)
   tag_fenced_code_block = 'force-pandoc-to-ouput-fenced-code-block'
-  textile.gsub!(/([^\n]<pre)(>)/, "\\1 class=\"#{tag_fenced_code_block}\"\\2")
+  textile.gsub!(/([^\n\r]\s*<pre\b)\s*(>)/, "\\1 class=\"#{tag_fenced_code_block}\"\\2")
 
   # Force <pre> to have a blank line before them
   # Without this fix, a list of items containing <pre> would not be interpreted as a list at all.
-  textile.gsub!(/([^\n])(<pre)/, "\\1\n\n\\2")
+  textile.gsub!(/([^\n\r]\s*)(<pre\b)/, "\\1\n\n\\2")
 
   # Drop table colspan/rowspan notation ("|\2." or "|/2.") because pandoc does not support it
   # See https://github.com/jgm/pandoc/issues/22

--- a/convert_textile_to_markdown.rake
+++ b/convert_textile_to_markdown.rake
@@ -67,6 +67,7 @@ def convert_textile_to_markdown(textile)
   textile.gsub!(/-          # (\d+)/, "* \\1")
 
   src = Tempfile.new('src')
+  src.binmode
   src.write(textile)
   src.close
   dst = Tempfile.new('dst')

--- a/convert_textile_to_markdown.rake
+++ b/convert_textile_to_markdown.rake
@@ -38,14 +38,6 @@ def convert_textile_to_markdown(textile)
   tag_code = 'pandoc-unescaped-single-backtick'
   textile.gsub!(/@([\S]+@[\S]+)@/, tag_code + '\\1' + tag_code)
 
-  # Drop table colspan/rowspan notation ("|\2." or "|/2.") because pandoc does not support it
-  # See https://github.com/jgm/pandoc/issues/22
-  textile.gsub!(/\|[\/\\]\d\. /, '| ')
-
-  # Drop table alignement notation ("|>." or "|<." or "|=.") because pandoc does not support it
-  # See https://github.com/jgm/pandoc/issues/22
-  textile.gsub!(/\|[<>=]\. /, '| ')
-
   # Move the class from <code> to <pre> so pandoc can generate a code block with correct language
   textile.gsub!(/(<pre)(><code)( class="[^"]*")(>)/, '\\1\\3\\2\\4')
 
@@ -60,6 +52,14 @@ def convert_textile_to_markdown(textile)
   # Force <pre> to have a blank line before them
   # Without this fix, a list of items containing <pre> would not be interpreted as a list at all.
   textile.gsub!(/([^\n])(<pre)/, "\\1\n\n\\2")
+
+  # Drop table colspan/rowspan notation ("|\2." or "|/2.") because pandoc does not support it
+  # See https://github.com/jgm/pandoc/issues/22
+  textile.gsub!(/\|[\/\\]\d\. /, '| ')
+
+  # Drop table alignement notation ("|>." or "|<." or "|=.") because pandoc does not support it
+  # See https://github.com/jgm/pandoc/issues/22
+  textile.gsub!(/\|[<>=]\. /, '| ')
 
   # Some malformed textile content make pandoc run extremely slow,
   # so we convert it to proper textile before hitting pandoc

--- a/convert_textile_to_markdown.rake
+++ b/convert_textile_to_markdown.rake
@@ -33,9 +33,20 @@ end
 def convert_textile_to_markdown(textile)
   require 'tempfile'
 
+  # Replace any non <pre> or <code> tags that are not contained in a <pre> block
+  # with @ to format it as inline code;
+  # This works around the problem that Textile allows XML tags displayed
+  # as is while Redmine Markdown filters those out;
+  # Because those pseudo XML could be part of a word, we need to inject a placeholder
+  # because pandoc is not able to render that corretly
+  tag_code = 'pandoc-unescaped-single-backtick'
+  textile.gsub!(/(<pre\b[^>]*>)?(?(1)([\s\S]*?<\/pre>)|(<[\/>]?(?!pre\b|code\b)[^\/>]+[\/>]))/, '\\1\\2' + tag_code + '\\3' + tag_code)
+
+  # Replace inline <code> tags (that doesn't contain any linebreaks in its content) with @ to format it as inline code
+  textile.gsub!(/<code\b[^>]*>([\S\t ]*?)<\/code>/, '@\\1@')
+
   # Redmine support @ inside inline code marked with @ (such as "@git@github.com@"), but not pandoc.
   # So we inject a placeholder that will be replaced later on with a real backtick.
-  tag_code = 'pandoc-unescaped-single-backtick'
   textile.gsub!(/@([\S]+@[\S]+)@/, tag_code + '\\1' + tag_code)
 
   # Move the class from <code> to <pre> so pandoc can generate a code block with correct language
@@ -99,6 +110,7 @@ def convert_textile_to_markdown(textile)
   markdown.gsub!(' ' + tag_fenced_code_block, '')
 
   # Replace placeholder with real backtick
+  markdown.gsub!(tag_code + tag_code, '')
   markdown.gsub!(tag_code, '`')
 
   # Un-escape Redmine link syntax to wiki pages

--- a/convert_textile_to_markdown.rake
+++ b/convert_textile_to_markdown.rake
@@ -15,7 +15,7 @@ task :convert_textile_to_markdown => :environment do
     print the_class.name
     the_class.find_each do |model|
       attributes.each do |attribute|
-
+        print model.id
         textile = model[attribute]
         if textile != nil
           markdown = convert_textile_to_markdown(textile)

--- a/convert_textile_to_markdown.rake
+++ b/convert_textile_to_markdown.rake
@@ -49,8 +49,8 @@ def convert_textile_to_markdown(textile)
   # So we inject a placeholder that will be replaced later on with a real backtick.
   textile.gsub!(/@([\S]+@[\S]+)@/, tag_code + '\\1' + tag_code)
 
-  # Move the class from <code> to <pre> so pandoc can generate a code block with correct language
-  textile.gsub!(/(<pre)(><code)( class="[^"]*")(>)/, '\\1\\3\\2\\4')
+  # Move the class from <code> to <pre> and remove <code> so pandoc can generate a code block with correct language
+  textile.gsub!(/(<pre\b)\s*(>)\s*<code\b(\s+class="[^"]*")?[^>]*>([\s\S]*?)<\/code>\s*(<\/pre>)/, '\\1\\3\\2\\4\\5')
 
   # Inject a class in all <pre> that do not have a blank line before them
   # This is to force pandoc to use fenced code block (```) otherwise it would


### PR DESCRIPTION
Tested on windows with latest pandoc 1.19.2.1
* avoid linebreak conversion by dumping models "as is"
* more robust regex
* delete `<code>` from `<pre><code>` block to avoid been displayed
* additional replacements for unescaped XML used in Textitle text