### PR TITLE
Add error handling

### DIFF
--- a/convert_textile_to_markdown.rake
+++ b/convert_textile_to_markdown.rake
@@ -29,7 +29,14 @@ task :convert_textile_to_markdown => :environment do
         textile = model[attribute]
         if textile != nil
           markdown = convert_textile_to_markdown(textile)
-          model.update_column(attribute, markdown)
+          begin
+            # We may encounter errors when saving the new value.
+            # For example, if it exceeds the maximum size allowed by SQL column
+            model.update_column(attribute, markdown)
+          rescue
+            puts
+            puts "Conversion failed for #{the_class} with id #{model.id}"
+          end
         end
       end
       count += 1


### PR DESCRIPTION
I ran this script on a pretty big redmine instance (about 800000 elements to convert), and ran into a few errors, that were crashing the script.

This PR adds a simple error handling (that basically just catches everything, tells you which items you had errors on, and keeps going), so that errors on a few items don't crash the whole conversion process.

For example, in my case, there were about 20 errors. I don't really mind, I can fix them manually if required.